### PR TITLE
MVVM, ReactorKit 비교 PR

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import Domain
-import Data
 import Presentation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -21,15 +20,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
-        let vc = UIViewController()
-        vc.view.backgroundColor = .white
+        let vc = MainTabBarController()
+        
         window.rootViewController = vc
         self.window = window
         window.makeKeyAndVisible()
-        
-        let _ = DomainTest()
-        let _ = RepositoryTest()
-        let _ = PresentationTest()
+
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Projects/Presentation/Sources/MVVM/MVVMViewController.swift
+++ b/Projects/Presentation/Sources/MVVM/MVVMViewController.swift
@@ -8,12 +8,110 @@
 import Foundation
 
 import UIKit
+import Then
+import PinLayout
+import FlexLayout
+import RxSwift
+import RxCocoa
 
 class MVVMViewController: UIViewController {
 
+  let titleLabel = UILabel().then {
+    $0.text = "MVVM"
+    $0.font = .systemFont(ofSize: 30)
+  }
 
+  let flexContainer = UIView()
+
+  let plusButton = UIButton().then {
+    $0.setImage(.init(systemName: "plus"), for: .normal)
+  }
+
+  let minusButton = UIButton().then {
+    $0.setImage(.init(systemName: "minus"), for: .normal)
+  }
+
+  let countLabel = UILabel().then {
+    $0.text = "0"
+  }
+
+  let viewModel = ViewModel()
+  let disposeBag = DisposeBag()
+
+
+  // MARK: Life Cycle
 
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    defineLayout()
+
+    bind(with: viewModel)
+  }
+
+
+  // MARK: Binding
+
+  private func bind(with viewModel: ViewModel) {
+
+    // MARK: Input
+
+    plusButton.rx.tap
+      .subscribe(with: self) { `self`, _ in
+        self.viewModel.plus()
+      }
+      .disposed(by: disposeBag)
+
+    minusButton.rx.tap
+      .subscribe(with: self) { `self`, _ in
+        self.viewModel.minus()
+      }
+      .disposed(by: disposeBag)
+
+
+    // MARK: Output
+
+    viewModel.text
+      .subscribe(with: self) { `self`, text in
+        self.countLabel.text = text
+
+        self.countLabel.flex.markDirty()
+        self.view.setNeedsLayout()
+      }
+      .disposed(by: disposeBag)
+  }
+
+
+  // MARK: Layout
+
+  private func defineLayout() {
+    view.backgroundColor = .white
+    view.addSubview(flexContainer)
+
+    flexContainer.flex
+      .alignItems(.center)
+      .define { flex in
+        flex.addItem(titleLabel)
+          .marginTop(20.0)
+
+        flex.addItem()
+          .grow(1.0)
+          .alignItems(.center)
+          .direction(.row)
+          .define { flex in
+            flex.addItem(minusButton)
+              .marginEnd(10.0)
+
+            flex.addItem(countLabel)
+              .marginEnd(10.0)
+
+            flex.addItem(plusButton)
+          }
+      }
+  }
+
+  override func viewDidLayoutSubviews() {
+    flexContainer.pin.all(view.pin.safeArea)
+    flexContainer.flex.layout()
   }
 }

--- a/Projects/Presentation/Sources/MVVM/ViewModel.swift
+++ b/Projects/Presentation/Sources/MVVM/ViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  ViewModel.swift
+//  Presentation
+//
+//  Created by 박천송 on 2023/04/25.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+protocol ViewModelInput {
+  func plus()
+  func minus()
+}
+
+protocol ViewModelOutput {
+  var text: BehaviorRelay<String> { get }
+}
+
+class ViewModel: ViewModelOutput {
+
+  var text: BehaviorRelay<String> = .init(value: "0")
+
+}
+
+extension ViewModel: ViewModelInput {
+  func plus() {
+    let number = Int(text.value) ?? 0
+
+    text.accept(String(number + 1))
+  }
+
+  func minus() {
+    let number = Int(text.value) ?? 0
+
+    text.accept(String(number - 1))
+  }
+}

--- a/Projects/Presentation/Sources/MainTab/MainTabBarController.swift
+++ b/Projects/Presentation/Sources/MainTab/MainTabBarController.swift
@@ -6,3 +6,22 @@
 //
 
 import Foundation
+
+import UIKit
+
+public class MainTabBarController: UITabBarController {
+
+  let mvvm = MVVMViewController()
+  let reactorKit = ReactorViewController()
+
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+
+    tabBar.isHidden = false
+
+    mvvm.tabBarItem.title = "MVVM"
+    reactorKit.tabBarItem.title = "ReactorKit"
+
+    viewControllers = [mvvm, reactorKit]
+  }
+}

--- a/Projects/Presentation/Sources/ReactorKit/ReactorKit.swift
+++ b/Projects/Presentation/Sources/ReactorKit/ReactorKit.swift
@@ -1,0 +1,67 @@
+//
+//  ReactorKit.swift
+//  Presentation
+//
+//  Created by 박천송 on 2023/04/25.
+//
+
+import Foundation
+
+import ReactorKit
+
+class ReactorKit: Reactor {
+  enum Action {
+    case plusButtonTapped
+    case minusButtonTapped
+  }
+
+  enum Mutation {
+    case setText(String)
+  }
+
+  struct State {
+    var text = "0"
+  }
+
+  
+  // MARK: Properties
+
+  let initialState: State
+
+
+  // MARK: initializing
+
+  init() {
+    defer { _ = self.state }
+    self.initialState = State()
+  }
+
+
+  // MARK: Mutate & Reduce
+  // 비즈니스 로직이 구현되는 부분이에요
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .plusButtonTapped:
+      let number = Int(currentState.text) ?? 0
+
+      return .just(Mutation.setText(String(number + 1)))
+
+    case .minusButtonTapped:
+      let number = Int(currentState.text) ?? 0
+
+      return .just(Mutation.setText(String(number - 1)))
+    }
+  }
+
+  // 상태를 바꿔주는 부분이에요 해당 상태를 뷰에서 바인딩해요
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+
+    switch mutation {
+    case .setText(let text):
+      newState.text = text
+    }
+
+    return newState
+  }
+}

--- a/Projects/Presentation/Sources/ReactorKit/ReactorViewController.swift
+++ b/Projects/Presentation/Sources/ReactorKit/ReactorViewController.swift
@@ -6,3 +6,105 @@
 //
 
 import Foundation
+
+import UIKit
+import Then
+import PinLayout
+import FlexLayout
+import RxSwift
+import RxCocoa
+import ReactorKit
+
+class ReactorViewController: UIViewController, StoryboardView {
+  typealias Reactor = ReactorKit
+
+  var disposeBag = DisposeBag()
+
+  let titleLabel = UILabel().then {
+    $0.text = "ReactorKit"
+    $0.font = .systemFont(ofSize: 30)
+  }
+
+  let flexContainer = UIView()
+
+  let plusButton = UIButton().then {
+    $0.setImage(.init(systemName: "plus"), for: .normal)
+  }
+
+  let minusButton = UIButton().then {
+    $0.setImage(.init(systemName: "minus"), for: .normal)
+  }
+
+  let countLabel = UILabel().then {
+    $0.text = "0"
+  }
+
+
+  // MARK: Life Cycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.reactor = ReactorKit()
+
+    defineLayout()
+  }
+
+  func bind(reactor: ReactorKit) {
+    plusButton.rx.tap
+      .map { Reactor.Action.plusButtonTapped }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    minusButton.rx.tap
+      .map { Reactor.Action.minusButtonTapped }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+
+    // ReactorKit은 State객체를 스트림으로 만들어요 그래서
+    // 해당값이 바뀌지 않아도 이벤트가 발생해 distinctUntilChanged() 오퍼레이터를 사용해야해요
+    reactor.state.map(\.text)
+      .distinctUntilChanged()
+      .subscribe(with: self) { `self`, text in
+        self.countLabel.text = text
+
+        self.countLabel.flex.markDirty()
+        self.view.setNeedsLayout()
+      }
+      .disposed(by: disposeBag)
+  }
+
+
+  // MARK: Layout
+
+  private func defineLayout() {
+    view.backgroundColor = .white
+    view.addSubview(flexContainer)
+
+    flexContainer.flex
+      .alignItems(.center)
+      .define { flex in
+        flex.addItem(titleLabel)
+          .marginTop(20.0)
+
+        flex.addItem()
+          .grow(1.0)
+          .alignItems(.center)
+          .direction(.row)
+          .define { flex in
+            flex.addItem(minusButton)
+              .marginEnd(10.0)
+
+            flex.addItem(countLabel)
+              .marginEnd(10.0)
+
+            flex.addItem(plusButton)
+          }
+      }
+  }
+
+  override func viewDidLayoutSubviews() {
+    flexContainer.pin.all(view.pin.safeArea)
+    flexContainer.flex.layout()
+  }
+}


### PR DESCRIPTION
### MVVM 과 ReactorKit 간단한 예제로 구현한 비교 PR이에요

### MVVM
1. `ViewModel` 에서 protocol로 Input Output을 정의해요 
2. `View`는 `ViewModel`의 Input 함수를 실행해요
3. 비즈니스로직은 `ViewModel`의 Input프로토콜 구현부에 작성돼요
4. 비즈니스로직을 처리하고 결과를 Output 스트림에 이벤트를 발생시켜요
```Swift
func plus() {
    let number = Int(text.value) ?? 0

    text.accept(String(number + 1))
  }
```
5. 해당 Output 스트림을 `View`에서 바인딩해요
```Swift
viewModel.text
      .bind(to: textField.rx.text)
      .disposed(by: disposeBag)
```

### ReactorKit
1. `ReactorKit`에서 `Action`, `Mutation`, `State`를 정의해요
2. `ViewModel`의 Input은 `Action`, Output은 `State`에요, `Mutation`은 `Action`을 받았을때 해야할 작업을 정의해요
3. `Action`이 이벤트가 발생하면 mutate함수가 실행돼요 -> mutate함수에 작성한 비즈니스 로직을 실행해요
```Swift
func mutate(action: Action) -> Observable<Mutation> {
  switch action {
  case .plusButtonTapped:
    let number = Int(currentState.text) ?? 0
    return .just(Mutation.setText(String(number + 1)))

  case .minusButtonTapped:
    let number = Int(currentState.text) ?? 0
    return .just(Mutation.setText(String(number - 1)))
  }
}
```
4. mutate에서 비즈니스 로직을 처리하면 `State`의 상태값을 바꿔줘요
```Swift
func reduce(state: State, mutation: Mutation) -> State {
  var newState = state
  switch mutation {
  case .setText(let text):
    newState.text = text
  }
  return newState
}
```
5. 바뀐 상태값을 `View`에서 바인딩해요